### PR TITLE
ci(workflows): use go.mod for Go version

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.24.x
+          go-version-file: 'go.mod'
   
       - name: coverage
         id: coverage

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: 'go.mod'
       - name: Install task
         uses: jaxxstorm/action-install-gh-release@v2.1.0
         with:


### PR DESCRIPTION
- coverage.yml: replace `go-version: 1.24.x` with `go-version-file: 'go.mod'`
- linter.yml: replace `go-version: stable` with `go-version-file: 'go.mod'`

Closes #100