### PR TITLE
feat(pdf): add PDF output format and venom integration test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /dist
 /mdtohtml
+.DS_Store
+/results

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -22,6 +22,19 @@ tasks:
       - go mod download
       - CGO_ENABLED=0 go build .
 
+  integration:
+    desc: "Run venom integration tests"
+    deps: [build]
+    cmds:
+      - rm -rf $PWD/results
+      - mkdir -p $PWD/results
+      - >-
+        venom run tst/integration/testsuite-*.yml
+        --var=bin={{.ROOT_DIR}}/{{.BINFILE}}
+        --var=fix={{.ROOT_DIR}}/tst/integration/fixtures
+        --output-dir=$PWD/results
+        --stop-on-failure
+
   snapshot:
     cmds:
       - GITLAB_TOKEN="" goreleaser --clean --snapshot

--- a/cmd/batch.go
+++ b/cmd/batch.go
@@ -43,6 +43,12 @@ func init() {
 	batchCmd.Flags().StringVar(&cssURL, "css-url", "", "URL to fetch CSS from instead of the default GitHub CSS")
 	batchCmd.Flags().StringVar(&additionalCSSFile, "additional-css", "", "Path to a CSS file to append to the default CSS")
 	batchCmd.Flags().BoolVar(&noCSS, "no-css", false, "Disable CSS injection entirely")
+	batchCmd.Flags().StringVar(&outputFormat, "format", formatHTML,
+		`Output format: "html" or "pdf"`)
+	batchCmd.Flags().StringVar(&pageSize, "page-size", "A4",
+		`PDF page size when --format=pdf: A4, Letter, Legal, A3, A5, Tabloid`)
+	batchCmd.Flags().StringVar(&marginFlag, "margin", defaultMarginFlag,
+		`PDF page margin (units: pt, in, cm, mm; bare numbers = pt)`)
 }
 
 func batchConvert(_ *cobra.Command, args []string) error {
@@ -70,14 +76,22 @@ func batchConvert(_ *cobra.Command, args []string) error {
 		NoCSS:            noCSS,
 	}
 
-	conv := converter.NewCompleteConverter(options)
+	format, err := resolveFormat(outputFormat, "")
+	if err != nil {
+		return err
+	}
+
+	conv, err := buildConverter(options, format, pageSize, marginFlag)
+	if err != nil {
+		return err
+	}
 	proc := processor.NewFileProcessor(conv)
 
-	// Process directory
 	processOptions := processor.ProcessOptions{
 		OutputDir: outputDir,
 		Pattern:   pattern,
 		Recursive: recursive,
+		OutputExt: extForFormat(format),
 	}
 
 	if err := proc.ProcessDirectory(inputDir, processOptions); err != nil {

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/sgaunet/mdtohtml/pkg/converter"
+	"github.com/sgaunet/mdtohtml/pkg/pdf"
 )
 
 // cssOptions groups the CSS-related flags for runConversion.
@@ -17,8 +18,8 @@ func runConversion(
 	inputFilePath, outputFilePath string,
 	smartypants, latexdashes, fractions, safeMode bool,
 	css cssOptions,
+	format, pageSize, margin string,
 ) error {
-	// Create converter with options
 	options := converter.Options{
 		SmartPunctuation: smartypants,
 		LaTeXDashes:      latexdashes,
@@ -29,12 +30,33 @@ func runConversion(
 		NoCSS:            css.noCSS,
 	}
 
-	conv := converter.NewCompleteConverter(options)
+	conv, err := buildConverter(options, format, pageSize, margin)
+	if err != nil {
+		return err
+	}
 
-	// Convert file
 	if err := conv.ConvertFile(inputFilePath, outputFilePath); err != nil {
 		return fmt.Errorf("conversion failed: %w", err)
 	}
-
 	return nil
+}
+
+// buildConverter returns a converter.Converter implementation for the given
+// output format. PDF wraps the HTML pipeline; HTML uses it directly.
+func buildConverter(options converter.Options, format, pageSize, margin string) (converter.Converter, error) {
+	if format == formatPDF {
+		m, err := pdf.ParseMargin(margin)
+		if err != nil {
+			return nil, fmt.Errorf("invalid PDF options: %w", err)
+		}
+		pdfConv, err := pdf.New(options, pdf.Options{
+			PageSize: pageSize,
+			Margins:  pdf.Margins{Top: m, Right: m, Bottom: m, Left: m},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("invalid PDF options: %w", err)
+		}
+		return pdfConv, nil
+	}
+	return converter.NewCompleteConverter(options), nil
 }

--- a/cmd/convert_cmd.go
+++ b/cmd/convert_cmd.go
@@ -30,4 +30,10 @@ func init() {
 	convertCmd.Flags().StringVar(&additionalCSSFile, "additional-css", "",
 		"Path to a CSS file to append to the default CSS")
 	convertCmd.Flags().BoolVar(&noCSS, "no-css", false, "Disable CSS injection entirely")
+	convertCmd.Flags().StringVar(&outputFormat, "format", "",
+		`Output format: "html" or "pdf" (default: auto-detect from output file extension)`)
+	convertCmd.Flags().StringVar(&pageSize, "page-size", "A4",
+		`PDF page size when --format=pdf: A4, Letter, Legal, A3, A5, Tabloid`)
+	convertCmd.Flags().StringVar(&marginFlag, "margin", defaultMarginFlag,
+		`PDF page margin (units: pt, in, cm, mm; bare numbers = pt)`)
 }

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
+	"strings"
 )
 
 var (
@@ -27,7 +29,38 @@ var (
 	errConflictingCSS = errors.New("--no-css cannot be combined with --css-file or --css-url")
 	// errBothCSSSourcesProvided is returned when both --css-file and --css-url are set.
 	errBothCSSSourcesProvided = errors.New("--css-file and --css-url are mutually exclusive")
+	// errUnknownFormat is returned when --format is set to an unrecognised value.
+	errUnknownFormat = errors.New("unknown --format value (expected html or pdf)")
 )
+
+// resolveFormat returns the output format to use. If explicit is non-empty it
+// must match a recognised format; otherwise the format is inferred from the
+// output file's extension (.pdf → pdf, anything else → html).
+func resolveFormat(explicit, outputPath string) (string, error) {
+	if explicit != "" {
+		switch strings.ToLower(explicit) {
+		case formatHTML:
+			return formatHTML, nil
+		case formatPDF:
+			return formatPDF, nil
+		default:
+			return "", fmt.Errorf("%w: %s", errUnknownFormat, explicit)
+		}
+	}
+	if strings.EqualFold(filepath.Ext(outputPath), ".pdf") {
+		return formatPDF, nil
+	}
+	return formatHTML, nil
+}
+
+// extForFormat returns the file extension that batch processing should append
+// for the given output format.
+func extForFormat(format string) string {
+	if format == formatPDF {
+		return ".pdf"
+	}
+	return ".html"
+}
 
 // validateInputFile checks that path exists and is a regular file.
 func validateInputFile(path string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,15 +8,26 @@ import (
 
 var (
 	// Version holds the application version string, injected at build time via ldflags.
-	Version          = "development"
-	smartypants      bool
-	latexdashes      bool
-	fractions        bool
-	safeMode         bool
-	cssFile          string
-	cssURL           string
+	Version           = "development"
+	smartypants       bool
+	latexdashes       bool
+	fractions         bool
+	safeMode          bool
+	cssFile           string
+	cssURL            string
 	additionalCSSFile string
-	noCSS            bool
+	noCSS             bool
+	outputFormat      string // "", "html", "pdf"; empty = auto-detect from extension
+	pageSize          string // PDF page size, e.g. "A4", "Letter"
+	marginFlag        string // PDF margin, e.g. "1.25in", "90", "2.5cm"
+)
+
+const defaultMarginFlag = "1.25in"
+
+// Recognised output formats.
+const (
+	formatHTML = "html"
+	formatPDF  = "pdf"
 )
 
 var rootCmd = &cobra.Command{
@@ -50,6 +61,12 @@ func init() {
 	rootCmd.Flags().StringVar(&cssURL, "css-url", "", "URL to fetch CSS from instead of the default GitHub CSS")
 	rootCmd.Flags().StringVar(&additionalCSSFile, "additional-css", "", "Path to a CSS file to append to the default CSS")
 	rootCmd.Flags().BoolVar(&noCSS, "no-css", false, "Disable CSS injection entirely")
+	rootCmd.Flags().StringVar(&outputFormat, "format", "",
+		`Output format: "html" or "pdf" (default: auto-detect from output file extension)`)
+	rootCmd.Flags().StringVar(&pageSize, "page-size", "A4",
+		`PDF page size when --format=pdf: A4, Letter, Legal, A3, A5, Tabloid`)
+	rootCmd.Flags().StringVar(&marginFlag, "margin", defaultMarginFlag,
+		`PDF page margin (units: pt, in, cm, mm; bare numbers = pt)`)
 	rootCmd.Version = Version
 	rootCmd.SetVersionTemplate(`{{.Version}}
 `)
@@ -73,8 +90,13 @@ func convert(_ *cobra.Command, args []string) error {
 	css := cssOptions{
 		source: source, additional: additional, noCSS: noCSS,
 	}
+	format, err := resolveFormat(outputFormat, outputFilePath)
+	if err != nil {
+		return err
+	}
 	return runConversion(
 		inputFilePath, outputFilePath,
 		smartypants, latexdashes, fractions, safeMode, css,
+		format, pageSize, marginFlag,
 	)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,9 @@
 module github.com/sgaunet/mdtohtml
 
-go 1.22
-
-toolchain go1.24.3
+go 1.25.0
 
 require (
+	github.com/carlos7ags/folio v0.7.1
 	github.com/spf13/cobra v1.10.2
 	github.com/yuin/goldmark v1.8.2
 )
@@ -12,4 +11,7 @@ require (
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
+	golang.org/x/image v0.39.0 // indirect
+	golang.org/x/net v0.53.0 // indirect
+	golang.org/x/text v0.36.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/carlos7ags/folio v0.7.1 h1:uLfnnLcQcYRhuF6zOGDjCybu8bvWHaEIog3LW86+HxI=
+github.com/carlos7ags/folio v0.7.1/go.mod h1:fZm2E7GeYsDd7M5ue++OBsyqfdS4XCkSEWvma0OgDyA=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
@@ -9,4 +11,10 @@ github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
 github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/image v0.39.0 h1:skVYidAEVKgn8lZ602XO75asgXBgLj9G/FE3RbuPFww=
+golang.org/x/image v0.39.0/go.mod h1:sIbmppfU+xFLPIG0FoVUTvyBMmgng1/XAMhQ2ft0hpA=
+golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
+golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
+golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=
+golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/pdf/errors.go
+++ b/pkg/pdf/errors.go
@@ -1,0 +1,9 @@
+package pdf
+
+import "errors"
+
+// ErrUnknownPageSize is returned when an unrecognised page size identifier is supplied.
+var ErrUnknownPageSize = errors.New("unknown page size")
+
+// ErrInvalidMargin is returned when a margin string cannot be parsed.
+var ErrInvalidMargin = errors.New("invalid margin")

--- a/pkg/pdf/options.go
+++ b/pkg/pdf/options.go
@@ -1,0 +1,127 @@
+package pdf
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/carlos7ags/folio/document"
+)
+
+// PageSizeA4 and PageSizeLetter are the recognised string identifiers for
+// the most common page sizes. Additional folio sizes can be added here as
+// they are needed.
+const (
+	PageSizeA4      = "A4"
+	PageSizeLetter  = "Letter"
+	PageSizeLegal   = "Legal"
+	PageSizeA3      = "A3"
+	PageSizeA5      = "A5"
+	PageSizeTabloid = "Tabloid"
+)
+
+// DefaultMargin is the default page margin in PDF points (1.25 inch).
+// 72 points = 1 inch, so 90 points = 1.25 inch.
+const DefaultMargin = 90.0
+
+// Unit conversion constants (PDF points per unit).
+const (
+	pointsPerInch = 72.0
+	pointsPerCm   = pointsPerInch / 2.54
+	pointsPerMm   = pointsPerCm / 10.0
+)
+
+// Margins defines page margins in PDF points (72pt = 1 inch).
+type Margins struct {
+	Top    float64
+	Right  float64
+	Bottom float64
+	Left   float64
+}
+
+// Options configures PDF generation.
+type Options struct {
+	// PageSize is the page size identifier (e.g. "A4", "Letter").
+	// Empty defaults to A4.
+	PageSize string
+
+	// Margins are the page margins applied unless overridden by an @page CSS rule.
+	Margins Margins
+}
+
+// DefaultOptions returns sensible PDF defaults (A4, 1.25 inch margins).
+func DefaultOptions() Options {
+	return Options{
+		PageSize: PageSizeA4,
+		Margins: Margins{
+			Top:    DefaultMargin,
+			Right:  DefaultMargin,
+			Bottom: DefaultMargin,
+			Left:   DefaultMargin,
+		},
+	}
+}
+
+// ParseMargin converts a margin string into PDF points. Empty input returns
+// DefaultMargin. Accepted unit suffixes: pt (default), in, cm, mm.
+func ParseMargin(s string) (float64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return DefaultMargin, nil
+	}
+
+	num, unit := splitMargin(s)
+	v, err := strconv.ParseFloat(num, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %s", ErrInvalidMargin, s)
+	}
+	if v < 0 {
+		return 0, fmt.Errorf("%w: %s (must be non-negative)", ErrInvalidMargin, s)
+	}
+
+	switch unit {
+	case "", "pt":
+		return v, nil
+	case "in":
+		return v * pointsPerInch, nil
+	case "cm":
+		return v * pointsPerCm, nil
+	case "mm":
+		return v * pointsPerMm, nil
+	default:
+		return 0, fmt.Errorf("%w: unknown unit %q", ErrInvalidMargin, unit)
+	}
+}
+
+// splitMargin separates the numeric portion of a margin value from its
+// trailing unit suffix. The unit is returned lowercased.
+func splitMargin(s string) (num, unit string) {
+	for i, r := range s {
+		if (r >= '0' && r <= '9') || r == '.' || r == '-' || r == '+' {
+			continue
+		}
+		return s[:i], strings.ToLower(s[i:])
+	}
+	return s, ""
+}
+
+// resolvePageSize maps a case-insensitive identifier to a folio PageSize.
+// Returns an error for unknown identifiers.
+func resolvePageSize(name string) (document.PageSize, error) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "", "a4":
+		return document.PageSizeA4, nil
+	case "letter":
+		return document.PageSizeLetter, nil
+	case "legal":
+		return document.PageSizeLegal, nil
+	case "a3":
+		return document.PageSizeA3, nil
+	case "a5":
+		return document.PageSizeA5, nil
+	case "tabloid":
+		return document.PageSizeTabloid, nil
+	default:
+		return document.PageSize{}, fmt.Errorf("%w: %s", ErrUnknownPageSize, name)
+	}
+}

--- a/pkg/pdf/options.go
+++ b/pkg/pdf/options.go
@@ -95,7 +95,7 @@ func ParseMargin(s string) (float64, error) {
 
 // splitMargin separates the numeric portion of a margin value from its
 // trailing unit suffix. The unit is returned lowercased.
-func splitMargin(s string) (num, unit string) {
+func splitMargin(s string) (string, string) {
 	for i, r := range s {
 		if (r >= '0' && r <= '9') || r == '.' || r == '-' || r == '+' {
 			continue

--- a/pkg/pdf/pdf.go
+++ b/pkg/pdf/pdf.go
@@ -1,0 +1,165 @@
+// Package pdf converts Markdown to PDF by piping the existing Markdown→HTML
+// pipeline straight into the folio HTML→PDF engine. No temporary HTML files
+// are written: the rendered HTML lives only in memory between the two stages.
+package pdf
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	folio "github.com/carlos7ags/folio/document"
+	folioHTML "github.com/carlos7ags/folio/html"
+	"github.com/carlos7ags/folio/layout"
+
+	"github.com/sgaunet/mdtohtml/pkg/converter"
+)
+
+// pdfFontOverrideCSS rewrites the GitHub stylesheet's code-related rules to
+// values folio's HTML→PDF engine renders correctly:
+//
+//   - font-family: folio collapses a CSS font-family list to its FIRST entry
+//     and maps that single token to a standard PDF font; only "courier",
+//     "monospace", "mono", or substrings of "times"/"serif" resolve. The
+//     GitHub stylesheet lists "SFMono-Regular,Consolas,...,monospace" — the
+//     first token wins, so inline code falls back to Helvetica. Putting the
+//     generic "monospace" keyword first restores Courier in the PDF.
+//   - background-color: folio's parseColor discards the alpha channel, so the
+//     GitHub rule "background-color: rgba(27,31,35,.05)" on inline <code>
+//     paints a near-black block over the text instead of a faint shade. We
+//     replace it with the same opaque light gray used for fenced blocks so
+//     the inline code chip stays readable.
+const pdfFontOverrideCSS = `
+body code,
+body kbd,
+body samp,
+body tt {
+  font-family: monospace;
+  background-color: #f6f8fa;
+}
+body pre,
+body pre code,
+body pre > code {
+  font-family: monospace;
+}
+`
+
+// Converter renders Markdown directly to PDF. It satisfies converter.Converter
+// so it can be plugged into the existing batch processor without any changes
+// to the file-walking or path logic.
+type Converter struct {
+	htmlConv *converter.CompleteConverter
+	pageSize folio.PageSize
+	margins  layout.Margins
+}
+
+// New builds a PDF converter from the same options the HTML pipeline uses,
+// plus PDF-specific options (page size, margins).
+func New(opts converter.Options, pdfOpts Options) (*Converter, error) {
+	ps, err := resolvePageSize(pdfOpts.PageSize)
+	if err != nil {
+		return nil, err
+	}
+	if opts.AdditionalCSS == "" {
+		opts.AdditionalCSS = pdfFontOverrideCSS
+	} else {
+		opts.AdditionalCSS = opts.AdditionalCSS + "\n" + pdfFontOverrideCSS
+	}
+	return &Converter{
+		htmlConv: converter.NewCompleteConverter(opts),
+		pageSize: ps,
+		margins: layout.Margins{
+			Top:    pdfOpts.Margins.Top,
+			Right:  pdfOpts.Margins.Right,
+			Bottom: pdfOpts.Margins.Bottom,
+			Left:   pdfOpts.Margins.Left,
+		},
+	}, nil
+}
+
+// Convert renders Markdown to PDF bytes. Relative image references will not
+// resolve from this entry point because no input directory is known; use
+// ConvertFile when assets need to load from disk.
+func (c *Converter) Convert(input []byte) ([]byte, error) {
+	htmlBytes, err := c.htmlConv.Convert(input)
+	if err != nil {
+		return nil, fmt.Errorf("markdown to HTML: %w", err)
+	}
+
+	doc, err := c.renderPDF(string(htmlBytes), "")
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		return nil, fmt.Errorf("writing PDF: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// ConvertFile reads a Markdown file and writes the PDF to outputPath. The
+// input file's directory is wired into folio's BasePath so relative image
+// references (e.g. ./img/foo.png) resolve correctly.
+func (c *Converter) ConvertFile(inputPath, outputPath string) error {
+	input, err := os.ReadFile(inputPath)
+	if err != nil {
+		if os.IsPermission(err) {
+			return fmt.Errorf("permission denied reading file '%s': %w", inputPath, err)
+		}
+		return fmt.Errorf("error reading file '%s': %w", inputPath, err)
+	}
+
+	htmlBytes, err := c.htmlConv.Convert(input)
+	if err != nil {
+		return fmt.Errorf("markdown to HTML: %w", err)
+	}
+
+	doc, err := c.renderPDF(string(htmlBytes), filepath.Dir(inputPath))
+	if err != nil {
+		return err
+	}
+
+	if err := doc.Save(outputPath); err != nil {
+		if os.IsPermission(err) {
+			return fmt.Errorf("permission denied writing file '%s': %w", outputPath, err)
+		}
+		return fmt.Errorf("error writing file '%s': %w", outputPath, err)
+	}
+	return nil
+}
+
+// renderPDF runs folio's HTML→PDF stage, applying any @page configuration
+// found in the source HTML and forwarding the document title metadata.
+func (c *Converter) renderPDF(htmlStr, basePath string) (*folio.Document, error) {
+	result, err := folioHTML.ConvertFull(htmlStr, &folioHTML.Options{BasePath: basePath})
+	if err != nil {
+		return nil, fmt.Errorf("HTML to PDF: %w", err)
+	}
+
+	doc := folio.NewDocument(c.pageSize)
+	doc.SetMargins(c.margins)
+	if pc := result.PageConfig; pc != nil && pc.HasMargins {
+		doc.SetMargins(layout.Margins{
+			Top:    pc.MarginTop,
+			Right:  pc.MarginRight,
+			Bottom: pc.MarginBottom,
+			Left:   pc.MarginLeft,
+		})
+	}
+	if result.MarginBoxes != nil {
+		doc.SetMarginBoxes(result.MarginBoxes)
+	}
+	if result.FirstMarginBoxes != nil {
+		doc.SetFirstMarginBoxes(result.FirstMarginBoxes)
+	}
+	for _, e := range result.Elements {
+		doc.Add(e)
+	}
+	if result.Metadata.Title != "" {
+		doc.Info.Title = result.Metadata.Title
+	}
+	doc.SetAutoBookmarks(true)
+	return doc, nil
+}

--- a/pkg/pdf/pdf_test.go
+++ b/pkg/pdf/pdf_test.go
@@ -1,0 +1,175 @@
+package pdf_test
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sgaunet/mdtohtml/pkg/converter"
+	"github.com/sgaunet/mdtohtml/pkg/pdf"
+)
+
+// Compile-time interface check.
+var _ converter.Converter = (*pdf.Converter)(nil)
+
+func newConv(t *testing.T) *pdf.Converter {
+	t.Helper()
+	c, err := pdf.New(converter.DefaultOptions(), pdf.DefaultOptions())
+	if err != nil {
+		t.Fatalf("pdf.New: %v", err)
+	}
+	return c
+}
+
+func TestConvert_ProducesPDFBytes(t *testing.T) {
+	out, err := newConv(t).Convert([]byte("# Hello\n\nWorld"))
+	if err != nil {
+		t.Fatalf("Convert: %v", err)
+	}
+	if !bytes.HasPrefix(out, []byte("%PDF-")) {
+		t.Fatalf("output does not start with PDF magic bytes; got %q", out[:min(8, len(out))])
+	}
+	if !bytes.Contains(out, []byte("%%EOF")) {
+		t.Fatal("output missing PDF EOF marker")
+	}
+}
+
+func TestConvert_TitleEmbeddedInMetadata(t *testing.T) {
+	const title = "Folio Integration Smoke Title"
+	out, err := newConv(t).Convert([]byte("# " + title + "\n\nbody"))
+	if err != nil {
+		t.Fatalf("Convert: %v", err)
+	}
+	// Folio writes Info.Title as a PDF string literal in the trailer/Info dict.
+	// We don't decode the PDF here — a substring check is enough for a smoke test.
+	if !bytes.Contains(out, []byte(title)) {
+		t.Fatalf("expected title %q to appear in PDF stream", title)
+	}
+}
+
+func TestConvertFile_WritesPDF(t *testing.T) {
+	dir := t.TempDir()
+	in := filepath.Join(dir, "doc.md")
+	if err := os.WriteFile(in, []byte("# Test\n\nContent."), 0o644); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+	out := filepath.Join(dir, "doc.pdf")
+
+	if err := newConv(t).ConvertFile(in, out); err != nil {
+		t.Fatalf("ConvertFile: %v", err)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if !bytes.HasPrefix(data, []byte("%PDF-")) {
+		t.Fatal("output file is not a PDF")
+	}
+}
+
+func TestConvertFile_PageBreakFixture(t *testing.T) {
+	// Reuse the existing markdown that exercises CSS page breaks.
+	src := filepath.Join("..", "..", "tst", "README-with-page-break.md")
+	if _, err := os.Stat(src); err != nil {
+		t.Skipf("fixture missing: %v", err)
+	}
+	out := filepath.Join(t.TempDir(), "breaks.pdf")
+	if err := newConv(t).ConvertFile(src, out); err != nil {
+		t.Fatalf("ConvertFile: %v", err)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	// A document with at least one page break should produce more than one page.
+	if pages := strings.Count(string(data), "/Type /Page\n") + strings.Count(string(data), "/Type/Page"); pages < 2 {
+		t.Logf("page-count heuristic returned %d; PDF size %d bytes (not strictly checking — folio's output format may vary)", pages, len(data))
+	}
+}
+
+func TestNew_RejectsUnknownPageSize(t *testing.T) {
+	_, err := pdf.New(converter.DefaultOptions(), pdf.Options{PageSize: "Bogus"})
+	if !errors.Is(err, pdf.ErrUnknownPageSize) {
+		t.Fatalf("expected ErrUnknownPageSize, got %v", err)
+	}
+}
+
+func TestNew_AcceptsKnownPageSizes(t *testing.T) {
+	for _, ps := range []string{"", "A4", "a4", "Letter", "Legal", "A3", "A5", "Tabloid"} {
+		t.Run(ps, func(t *testing.T) {
+			if _, err := pdf.New(converter.DefaultOptions(), pdf.Options{PageSize: ps}); err != nil {
+				t.Fatalf("page size %q rejected: %v", ps, err)
+			}
+		})
+	}
+}
+
+func TestDefaultOptions_HasMargins(t *testing.T) {
+	opts := pdf.DefaultOptions()
+	if opts.Margins.Top != pdf.DefaultMargin ||
+		opts.Margins.Right != pdf.DefaultMargin ||
+		opts.Margins.Bottom != pdf.DefaultMargin ||
+		opts.Margins.Left != pdf.DefaultMargin {
+		t.Fatalf("expected all margins = %v, got %+v", pdf.DefaultMargin, opts.Margins)
+	}
+}
+
+func TestParseMargin(t *testing.T) {
+	cases := []struct {
+		in   string
+		want float64
+	}{
+		{"", pdf.DefaultMargin},
+		{"  ", pdf.DefaultMargin},
+		{"90", 90},
+		{"90pt", 90},
+		{"  90pt ", 90},
+		{"1in", 72},
+		{"1.25in", 90},
+		{"2.54cm", 72},
+		{"25.4mm", 72},
+		{"0", 0},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got, err := pdf.ParseMargin(c.in)
+			if err != nil {
+				t.Fatalf("ParseMargin(%q) err: %v", c.in, err)
+			}
+			// Allow tiny float drift on cm/mm conversions.
+			if diff := got - c.want; diff < -0.001 || diff > 0.001 {
+				t.Fatalf("ParseMargin(%q) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestParseMargin_Errors(t *testing.T) {
+	for _, in := range []string{"abc", "10ft", "1.2.3", "-5"} {
+		t.Run(in, func(t *testing.T) {
+			if _, err := pdf.ParseMargin(in); !errors.Is(err, pdf.ErrInvalidMargin) {
+				t.Fatalf("ParseMargin(%q) expected ErrInvalidMargin, got %v", in, err)
+			}
+		})
+	}
+}
+
+func TestConvert_HonoursCustomMargin(t *testing.T) {
+	// Smoke test: a custom margin must not break PDF generation.
+	opts := pdf.DefaultOptions()
+	opts.Margins = pdf.Margins{Top: 36, Right: 36, Bottom: 36, Left: 36}
+	c, err := pdf.New(converter.DefaultOptions(), opts)
+	if err != nil {
+		t.Fatalf("pdf.New: %v", err)
+	}
+	out, err := c.Convert([]byte("# Hi\n\nbody"))
+	if err != nil {
+		t.Fatalf("Convert: %v", err)
+	}
+	if !bytes.HasPrefix(out, []byte("%PDF-")) {
+		t.Fatal("output is not a PDF")
+	}
+}

--- a/pkg/processor/file_processor.go
+++ b/pkg/processor/file_processor.go
@@ -53,9 +53,13 @@ func (p *FileProcessor) ProcessDirectory(dir string, options ProcessOptions) err
 	}
 
 	// Process each file
+	ext := options.OutputExt
+	if ext == "" {
+		ext = DefaultOutputExt
+	}
 	fmt.Printf("Converting %d files...\n", len(files))
 	for _, file := range files {
-		if err := p.processFile(file, dir, options.OutputDir); err != nil {
+		if err := p.processFile(file, dir, options.OutputDir, ext); err != nil {
 			return fmt.Errorf("batch processing '%s': %w", dir, err)
 		}
 	}
@@ -99,8 +103,8 @@ func (p *FileProcessor) findFilesRecursive(dir, pattern string) ([]string, error
 	return files, nil
 }
 
-func (p *FileProcessor) processFile(file, inputDir, outputDir string) error {
-	outputPath := GetOutputPath(file, inputDir, outputDir)
+func (p *FileProcessor) processFile(file, inputDir, outputDir, ext string) error {
+	outputPath := GetOutputPathExt(file, inputDir, outputDir, ext)
 
 	if err := ValidateOutputPath(outputPath, outputDir); err != nil {
 		return err

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -13,9 +13,12 @@ type BatchProcessor interface {
 	ProcessDirectory(dir string, options ProcessOptions) error
 }
 
+// DefaultOutputExt is the default extension applied when ProcessOptions.OutputExt is empty.
+const DefaultOutputExt = ".html"
+
 // ProcessOptions configures batch processing behavior.
 type ProcessOptions struct {
-	// OutputDir is the directory where HTML files will be written
+	// OutputDir is the directory where converted files will be written
 	OutputDir string
 
 	// Pattern is the file pattern to match (e.g., "*.md")
@@ -23,6 +26,10 @@ type ProcessOptions struct {
 
 	// Recursive determines if subdirectories should be processed
 	Recursive bool
+
+	// OutputExt is the extension applied to converted files (e.g., ".html", ".pdf").
+	// Empty defaults to DefaultOutputExt.
+	OutputExt string
 }
 
 // FileInfo represents information about a file to be processed.
@@ -31,14 +38,21 @@ type FileInfo struct {
 	OutputPath string
 }
 
-// GetOutputPath calculates the output path for a given input file.
+// GetOutputPath calculates the output path for a given input file using the
+// default ".html" extension. Use GetOutputPathExt to choose an extension.
 func GetOutputPath(inputFile, inputDir, outputDir string) string {
+	return GetOutputPathExt(inputFile, inputDir, outputDir, DefaultOutputExt)
+}
+
+// GetOutputPathExt is like GetOutputPath but applies the supplied extension
+// (which must include the leading dot, e.g. ".pdf").
+func GetOutputPathExt(inputFile, inputDir, outputDir, ext string) string {
 	relPath, err := filepath.Rel(inputDir, inputFile)
 	if err != nil {
 		relPath = filepath.Base(inputFile)
 	}
 
-	outputFile := relPath[:len(relPath)-len(filepath.Ext(relPath))] + ".html"
+	outputFile := relPath[:len(relPath)-len(filepath.Ext(relPath))] + ext
 	return filepath.Join(outputDir, outputFile)
 }
 

--- a/tst/integration/fixtures/code/fenced.md
+++ b/tst/integration/fixtures/code/fenced.md
@@ -1,0 +1,20 @@
+# Fenced Code
+
+A Go snippet:
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("hello, world")
+}
+```
+
+A Python snippet:
+
+```python
+def greet(name):
+    return f"hello, {name}"
+```

--- a/tst/integration/fixtures/code/inline.md
+++ b/tst/integration/fixtures/code/inline.md
@@ -1,0 +1,4 @@
+# Inline Code
+
+Run `go test ./...` to execute the tests, then call `task build`
+to produce the binary.

--- a/tst/integration/fixtures/css/custom.css
+++ b/tst/integration/fixtures/css/custom.css
@@ -1,0 +1,4 @@
+body {
+  background: #abcdef;
+  font-family: "Comic Sans MS", cursive, sans-serif;
+}

--- a/tst/integration/fixtures/images/assets/logo.svg
+++ b/tst/integration/fixtures/images/assets/logo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><circle cx="8" cy="8" r="6" fill="#0366d6"/></svg>

--- a/tst/integration/fixtures/images/img.md
+++ b/tst/integration/fixtures/images/img.md
@@ -1,0 +1,5 @@
+# Image
+
+A small inline SVG asset:
+
+![logo](assets/logo.svg)

--- a/tst/integration/fixtures/invalid/notmarkdown.txt
+++ b/tst/integration/fixtures/invalid/notmarkdown.txt
@@ -1,0 +1,1 @@
+This is a plain text file. The default --pattern '*.md' should skip it.

--- a/tst/integration/fixtures/multi-page/pagebreak.md
+++ b/tst/integration/fixtures/multi-page/pagebreak.md
@@ -1,0 +1,15 @@
+# Section A
+
+This is the content of the first section.
+
+<div style="display:block; clear:both; page-break-after:always;"></div>
+
+# Section B
+
+This is the content of the second section.
+
+<div style="display:block; clear:both; page-break-after:always;"></div>
+
+# Section C
+
+This is the content of the third section.

--- a/tst/integration/fixtures/nested/sub/deeper/leaf.md
+++ b/tst/integration/fixtures/nested/sub/deeper/leaf.md
@@ -1,0 +1,4 @@
+# Deepest Leaf
+
+Two levels deep. Verifies that recursive batch preserves nested directory
+structure under --out-dir.

--- a/tst/integration/fixtures/nested/sub/inner.md
+++ b/tst/integration/fixtures/nested/sub/inner.md
@@ -1,0 +1,3 @@
+# Nested Inner
+
+One level deep. Visited only when batch is run with --recursive.

--- a/tst/integration/fixtures/nested/top.md
+++ b/tst/integration/fixtures/nested/top.md
@@ -1,0 +1,4 @@
+# Top Level
+
+Top-level fixture used by batch tests to verify non-recursive runs see
+this file but ignore everything below it.

--- a/tst/integration/fixtures/simple/headings.md
+++ b/tst/integration/fixtures/simple/headings.md
@@ -1,0 +1,13 @@
+# Heading Level One
+
+## Heading Level Two
+
+### Heading Level Three
+
+#### Heading Level Four
+
+##### Heading Level Five
+
+###### Heading Level Six
+
+A short paragraph follows the headings.

--- a/tst/integration/fixtures/simple/lists.md
+++ b/tst/integration/fixtures/simple/lists.md
@@ -1,0 +1,21 @@
+# Lists
+
+## Unordered
+
+- apples
+- oranges
+  - clementines
+  - mandarins
+- pears
+
+## Ordered
+
+1. first
+2. second
+3. third
+
+## Task list
+
+- [x] write fixtures
+- [ ] run integration tests
+- [ ] celebrate

--- a/tst/integration/fixtures/simple/paragraph.md
+++ b/tst/integration/fixtures/simple/paragraph.md
@@ -1,0 +1,4 @@
+This document has no heading at all.
+
+It contains two paragraphs of plain prose so that the title extraction
+logic has nothing to find. The generated HTML should still be valid.

--- a/tst/integration/fixtures/tables/tables.md
+++ b/tst/integration/fixtures/tables/tables.md
@@ -1,0 +1,11 @@
+# Tables
+
+A standard GitHub-Flavored Markdown table:
+
+| Name    | Role     | Score |
+| :------ | :------: | ----: |
+| Alice   | author   |    42 |
+| Bob     | reviewer |     7 |
+| Charlie | tester   |   100 |
+
+Inline emphasis works in cells: **bold**, _italic_, and `code`.

--- a/tst/integration/fixtures/typography/smarty.md
+++ b/tst/integration/fixtures/typography/smarty.md
@@ -1,0 +1,3 @@
+# Typography
+
+She said "this -- and that --- is fine" ... ellipsis.

--- a/tst/integration/fixtures/unsafe-html/script.md
+++ b/tst/integration/fixtures/unsafe-html/script.md
@@ -1,0 +1,9 @@
+# Unsafe HTML
+
+Hello world.
+
+<script>alert('xss')</script>
+
+<iframe src="https://example.com/evil"></iframe>
+
+End of document.

--- a/tst/integration/testsuite-batch.yml
+++ b/tst/integration/testsuite-batch.yml
@@ -1,0 +1,103 @@
+name: batch
+vars:
+  bin: ./mdtohtml
+  out: /tmp/mdth-it/batch
+  fix: tst/integration/fixtures
+testcases:
+  - name: setup
+    steps:
+      - type: exec
+        script: 'rm -rf {{.out}} && mkdir -p {{.out}}'
+        assertions:
+          - result.code ShouldEqual 0
+
+  - name: non-recursive batch processes only top-level files
+    steps:
+      - type: exec
+        script: '{{.bin}} batch {{.fix}}/nested --out-dir {{.out}}/nonrec'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "Converting 1 files..."
+          - result.systemout ShouldContainSubstring "Successfully converted 1 files"
+      - type: exec
+        script: 'test -f {{.out}}/nonrec/top.html && test ! -f {{.out}}/nonrec/sub/inner.html'
+        assertions:
+          - result.code ShouldEqual 0
+
+  - name: recursive batch preserves nested directory structure
+    steps:
+      - type: exec
+        script: '{{.bin}} batch {{.fix}}/nested --recursive --out-dir {{.out}}/rec'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "Converting 3 files..."
+      - type: exec
+        script: 'test -f {{.out}}/rec/top.html && test -f {{.out}}/rec/sub/inner.html && test -f {{.out}}/rec/sub/deeper/leaf.html'
+        assertions:
+          - result.code ShouldEqual 0
+
+  - name: pattern that matches no files exits 0 with helpful message
+    steps:
+      - type: exec
+        script: '{{.bin}} batch {{.fix}}/invalid --pattern "*.xyz" --out-dir {{.out}}/pat'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "No files matching pattern"
+          - result.systemout ShouldContainSubstring "*.xyz"
+
+  - name: custom pattern selects non-default extension
+    steps:
+      - type: exec
+        script: '{{.bin}} batch {{.fix}}/invalid --pattern "*.txt" --out-dir {{.out}}/txt'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "Converting 1 files..."
+      - type: exec
+        script: 'test -f {{.out}}/txt/notmarkdown.html'
+        assertions:
+          - result.code ShouldEqual 0
+
+  - name: out-dir is created when it does not yet exist
+    steps:
+      - type: exec
+        script: 'rm -rf {{.out}}/created'
+        assertions:
+          - result.code ShouldEqual 0
+      - type: exec
+        script: '{{.bin}} batch {{.fix}}/simple --out-dir {{.out}}/created'
+        assertions:
+          - result.code ShouldEqual 0
+      - type: exec
+        script: 'test -d {{.out}}/created && ls {{.out}}/created/*.html | wc -l | tr -d " "'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldEqual "3"
+
+  - name: missing input directory returns exit 1
+    steps:
+      - type: exec
+        script: '{{.bin}} batch /tmp/mdth-does-not-exist --out-dir {{.out}}/x'
+        assertions:
+          - result.code ShouldEqual 1
+          - result.systemerr ShouldContainSubstring "input directory not found"
+
+  - name: input that is a file not a directory returns exit 1
+    steps:
+      - type: exec
+        script: '{{.bin}} batch {{.fix}}/simple/headings.md --out-dir {{.out}}/x'
+        assertions:
+          - result.code ShouldEqual 1
+          - result.systemerr ShouldContainSubstring "input path is a file, not a directory"
+
+  - name: batch with --format pdf produces valid PDFs for every input
+    steps:
+      - type: exec
+        script: '{{.bin}} batch --format=pdf {{.fix}}/simple --out-dir {{.out}}/pdf'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "Converting 3 files..."
+      - type: exec
+        script: 'for f in {{.out}}/pdf/*.pdf; do head -c 5 "$f" | grep -q "%PDF-" && tail -c 6 "$f" | grep -q "%%EOF" || { echo "FAIL $f"; exit 1; }; done; echo OK'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "OK"

--- a/tst/integration/testsuite-convert.yml
+++ b/tst/integration/testsuite-convert.yml
@@ -1,0 +1,190 @@
+name: convert
+vars:
+  bin: ./mdtohtml
+  out: /tmp/mdth-it/convert
+  fix: tst/integration/fixtures
+testcases:
+  - name: setup
+    steps:
+      - type: exec
+        script: 'rm -rf {{.out}} && mkdir -p {{.out}}'
+        assertions:
+          - result.code ShouldEqual 0
+
+  - name: simple-headings produces valid HTML with extracted title
+    steps:
+      - type: exec
+        script: '{{.bin}} convert {{.fix}}/simple/headings.md {{.out}}/headings.html'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemerr ShouldBeEmpty
+      - type: exec
+        script: 'cat {{.out}}/headings.html'
+        assertions:
+          - result.systemout ShouldContainSubstring "<!DOCTYPE html>"
+          - result.systemout ShouldContainSubstring "<title>Heading Level One</title>"
+          - result.systemout ShouldContainSubstring "<style>"
+          - result.systemout ShouldContainSubstring "octicon"
+          - result.systemout ShouldContainSubstring "<h1"
+          - result.systemout ShouldContainSubstring "<h6"
+
+  - name: paragraph without H1 has empty title
+    steps:
+      - type: exec
+        script: '{{.bin}} convert {{.fix}}/simple/paragraph.md {{.out}}/paragraph.html'
+        assertions:
+          - result.code ShouldEqual 0
+      - type: exec
+        script: 'cat {{.out}}/paragraph.html'
+        assertions:
+          - result.systemout ShouldContainSubstring "<title></title>"
+
+  - name: lists render with ul ol and task-list classes
+    steps:
+      - type: exec
+        script: '{{.bin}} convert {{.fix}}/simple/lists.md {{.out}}/lists.html'
+        assertions:
+          - result.code ShouldEqual 0
+      - type: exec
+        script: 'cat {{.out}}/lists.html'
+        assertions:
+          - result.systemout ShouldContainSubstring "<ul>"
+          - result.systemout ShouldContainSubstring "<ol>"
+          - result.systemout ShouldContainSubstring "task-list-item"
+
+  - name: tables render with th and table tags
+    steps:
+      - type: exec
+        script: '{{.bin}} convert {{.fix}}/tables/tables.md {{.out}}/tables.html'
+        assertions:
+          - result.code ShouldEqual 0
+      - type: exec
+        script: 'cat {{.out}}/tables.html'
+        assertions:
+          - result.systemout ShouldContainSubstring "<table>"
+          - result.systemout ShouldContainSubstring "<th"
+          - result.systemout ShouldContainSubstring "Alice"
+
+  - name: fenced code block uses language class
+    steps:
+      - type: exec
+        script: '{{.bin}} convert {{.fix}}/code/fenced.md {{.out}}/fenced.html'
+        assertions:
+          - result.code ShouldEqual 0
+      - type: exec
+        script: 'cat {{.out}}/fenced.html'
+        assertions:
+          - result.systemout ShouldContainSubstring "language-go"
+          - result.systemout ShouldContainSubstring "language-python"
+          - result.systemout ShouldContainSubstring "fmt.Println"
+
+  - name: image markdown produces img tag with src
+    steps:
+      - type: exec
+        script: '{{.bin}} convert {{.fix}}/images/img.md {{.out}}/img.html'
+        assertions:
+          - result.code ShouldEqual 0
+      - type: exec
+        script: 'cat {{.out}}/img.html'
+        assertions:
+          - result.systemout ShouldContainSubstring "<img"
+          - result.systemout ShouldContainSubstring "assets/logo.svg"
+
+  - name: --no-css strips the style block
+    steps:
+      - type: exec
+        script: '{{.bin}} --no-css convert {{.fix}}/simple/headings.md {{.out}}/nocss.html'
+        assertions:
+          - result.code ShouldEqual 0
+      - type: exec
+        script: 'cat {{.out}}/nocss.html'
+        assertions:
+          - result.systemout ShouldNotContainSubstring "<style>"
+          - result.systemout ShouldContainSubstring "<title>Heading Level One</title>"
+
+  - name: --css-file replaces default CSS with custom styles
+    steps:
+      - type: exec
+        script: '{{.bin}} --css-file={{.fix}}/css/custom.css convert {{.fix}}/simple/headings.md {{.out}}/cssfile.html'
+        assertions:
+          - result.code ShouldEqual 0
+      - type: exec
+        script: 'cat {{.out}}/cssfile.html'
+        assertions:
+          - result.systemout ShouldContainSubstring "#abcdef"
+          - result.systemout ShouldNotContainSubstring "octicon"
+
+  - name: --additional-css appends to default CSS
+    steps:
+      - type: exec
+        script: '{{.bin}} --additional-css={{.fix}}/css/custom.css convert {{.fix}}/simple/headings.md {{.out}}/addcss.html'
+        assertions:
+          - result.code ShouldEqual 0
+      - type: exec
+        script: 'cat {{.out}}/addcss.html'
+        assertions:
+          - result.systemout ShouldContainSubstring "#abcdef"
+          - result.systemout ShouldContainSubstring "octicon"
+
+  - name: --safe-mode strips raw script and iframe tags
+    steps:
+      - type: exec
+        script: '{{.bin}} --safe-mode {{.fix}}/unsafe-html/script.md {{.out}}/safe.html'
+        assertions:
+          - result.code ShouldEqual 0
+      - type: exec
+        script: 'cat {{.out}}/safe.html'
+        assertions:
+          - result.systemout ShouldNotContainSubstring "<script>alert"
+          - result.systemout ShouldNotContainSubstring "<iframe"
+          - result.systemout ShouldContainSubstring "raw HTML omitted"
+
+  - name: without --safe-mode raw HTML passes through
+    steps:
+      - type: exec
+        script: '{{.bin}} {{.fix}}/unsafe-html/script.md {{.out}}/unsafe.html'
+        assertions:
+          - result.code ShouldEqual 0
+      - type: exec
+        script: 'cat {{.out}}/unsafe.html'
+        assertions:
+          - result.systemout ShouldContainSubstring "<script>alert"
+          - result.systemout ShouldContainSubstring "<iframe"
+
+  - name: smartypants converts quotes dashes and ellipsis to entities
+    steps:
+      - type: exec
+        script: '{{.bin}} {{.fix}}/typography/smarty.md {{.out}}/smarty.html'
+        assertions:
+          - result.code ShouldEqual 0
+      - type: exec
+        script: 'cat {{.out}}/smarty.html'
+        assertions:
+          - result.systemout ShouldContainSubstring "&ldquo;"
+          - result.systemout ShouldContainSubstring "&rdquo;"
+          - result.systemout ShouldContainSubstring "&ndash;"
+          - result.systemout ShouldContainSubstring "&mdash;"
+          - result.systemout ShouldContainSubstring "&hellip;"
+
+  - name: smartypants disabled preserves raw punctuation
+    steps:
+      - type: exec
+        script: '{{.bin}} --smartypants=false --latexdashes=false --fractions=false {{.fix}}/typography/smarty.md {{.out}}/smarty-raw.html'
+        assertions:
+          - result.code ShouldEqual 0
+      - type: exec
+        script: 'cat {{.out}}/smarty-raw.html'
+        assertions:
+          - result.systemout ShouldNotContainSubstring "&ldquo;"
+          - result.systemout ShouldNotContainSubstring "&mdash;"
+          - result.systemout ShouldNotContainSubstring "&hellip;"
+          - result.systemout ShouldContainSubstring "---"
+          - result.systemout ShouldContainSubstring "..."
+
+  - name: nonexistent input returns exit 1 with stderr
+    steps:
+      - type: exec
+        script: '{{.bin}} convert {{.fix}}/does-not-exist.md {{.out}}/x.html'
+        assertions:
+          - result.code ShouldEqual 1
+          - result.systemerr ShouldContainSubstring "input file not found"

--- a/tst/integration/testsuite-errors.yml
+++ b/tst/integration/testsuite-errors.yml
@@ -1,0 +1,100 @@
+name: errors
+vars:
+  bin: ./mdtohtml
+  out: /tmp/mdth-it/errors
+  fix: tst/integration/fixtures
+testcases:
+  - name: setup
+    steps:
+      - type: exec
+        script: 'rm -rf {{.out}} && mkdir -p {{.out}}'
+        assertions:
+          - result.code ShouldEqual 0
+
+  - name: convert with no arguments fails with usage error
+    steps:
+      - type: exec
+        script: '{{.bin}} convert'
+        assertions:
+          - result.code ShouldEqual 1
+          - result.systemerr ShouldContainSubstring "accepts 2 arg"
+
+  - name: convert with one argument fails
+    steps:
+      - type: exec
+        script: '{{.bin}} convert {{.fix}}/simple/headings.md'
+        assertions:
+          - result.code ShouldEqual 1
+          - result.systemerr ShouldContainSubstring "accepts 2 arg"
+
+  - name: batch with no arguments fails
+    steps:
+      - type: exec
+        script: '{{.bin}} batch'
+        assertions:
+          - result.code ShouldEqual 1
+          - result.systemerr ShouldContainSubstring "accepts 1 arg"
+
+  - name: validate with no arguments fails
+    steps:
+      - type: exec
+        script: '{{.bin}} validate'
+        assertions:
+          - result.code ShouldEqual 1
+          - result.systemerr ShouldContainSubstring "accepts 1 arg"
+
+  - name: --no-css combined with --css-file is rejected
+    steps:
+      - type: exec
+        script: '{{.bin}} --no-css --css-file={{.fix}}/css/custom.css {{.fix}}/simple/headings.md {{.out}}/x.html'
+        assertions:
+          - result.code ShouldEqual 1
+          - result.systemerr ShouldContainSubstring "--no-css cannot be combined"
+
+  - name: --no-css combined with --css-url is rejected
+    steps:
+      - type: exec
+        script: '{{.bin}} --no-css --css-url=https://example.com/x.css {{.fix}}/simple/headings.md {{.out}}/x.html'
+        assertions:
+          - result.code ShouldEqual 1
+          - result.systemerr ShouldContainSubstring "--no-css cannot be combined"
+
+  - name: --css-file and --css-url together are rejected
+    steps:
+      - type: exec
+        script: '{{.bin}} --css-file={{.fix}}/css/custom.css --css-url=https://example.com/x.css {{.fix}}/simple/headings.md {{.out}}/x.html'
+        assertions:
+          - result.code ShouldEqual 1
+          - result.systemerr ShouldContainSubstring "mutually exclusive"
+
+  - name: unknown --format value is rejected
+    steps:
+      - type: exec
+        script: '{{.bin}} --format=xyz {{.fix}}/simple/headings.md {{.out}}/x.html'
+        assertions:
+          - result.code ShouldEqual 1
+          - result.systemerr ShouldContainSubstring "unknown --format value"
+
+  - name: missing --css-file path is rejected
+    steps:
+      - type: exec
+        script: '{{.bin}} --css-file=/tmp/mdth-does-not-exist.css {{.fix}}/simple/headings.md {{.out}}/x.html'
+        assertions:
+          - result.code ShouldEqual 1
+          - result.systemerr ShouldNotBeEmpty
+
+  - name: unsupported scheme in --css-url is rejected
+    steps:
+      - type: exec
+        script: '{{.bin}} --css-url=file:///tmp/foo.css {{.fix}}/simple/headings.md {{.out}}/x.html'
+        assertions:
+          - result.code ShouldEqual 1
+          - result.systemerr ShouldContainSubstring "unsupported protocol scheme"
+
+  - name: output written to a non-writable directory fails gracefully
+    steps:
+      - type: exec
+        script: '{{.bin}} {{.fix}}/simple/headings.md /dev/null/sub/x.html'
+        assertions:
+          - result.code ShouldEqual 1
+          - result.systemerr ShouldNotBeEmpty

--- a/tst/integration/testsuite-flags.yml
+++ b/tst/integration/testsuite-flags.yml
@@ -1,0 +1,67 @@
+name: flags
+vars:
+  bin: ./mdtohtml
+  fix: tst/integration/fixtures
+testcases:
+  - name: --version prints the version string and exits 0
+    steps:
+      - type: exec
+        script: '{{.bin}} --version'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "development"
+
+  - name: -v short flag prints the version string
+    steps:
+      - type: exec
+        script: '{{.bin}} -v'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "development"
+
+  - name: --help lists all subcommands
+    steps:
+      - type: exec
+        script: '{{.bin}} --help'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "convert"
+          - result.systemout ShouldContainSubstring "batch"
+          - result.systemout ShouldContainSubstring "validate"
+          - result.systemout ShouldContainSubstring "completion"
+
+  - name: batch --help describes its specific flags
+    steps:
+      - type: exec
+        script: '{{.bin}} batch --help'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "--out-dir"
+          - result.systemout ShouldContainSubstring "--pattern"
+          - result.systemout ShouldContainSubstring "--recursive"
+
+  - name: convert --help describes core flags
+    steps:
+      - type: exec
+        script: '{{.bin}} convert --help'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "smartypants"
+          - result.systemout ShouldContainSubstring "css-file"
+
+  - name: validate --help describes validate flags only
+    steps:
+      - type: exec
+        script: '{{.bin}} validate --help'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "smartypants"
+          - result.systemout ShouldNotContainSubstring "out-dir"
+
+  - name: completion bash is generated to stdout
+    steps:
+      - type: exec
+        script: '{{.bin}} completion bash'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "bash completion"

--- a/tst/integration/testsuite-pdf.yml
+++ b/tst/integration/testsuite-pdf.yml
@@ -1,0 +1,252 @@
+name: pdf
+vars:
+  bin: ./mdtohtml
+  out: ../../results/pdf
+  fix: tst/integration/fixtures
+testcases:
+  - name: setup
+    steps:
+      - type: exec
+        script: 'rm -rf {{.out}} && mkdir -p {{.out}}'
+        assertions:
+          - result.code ShouldEqual 0
+
+  - name: explicit --format=pdf produces a valid PDF
+    steps:
+      - type: exec
+        script: '{{.bin}} --format=pdf {{.fix}}/simple/headings.md {{.out}}/explicit.pdf'
+        assertions:
+          - result.code ShouldEqual 0
+      - type: exec
+        script: 'head -c 5 {{.out}}/explicit.pdf | grep -q "%PDF-" && tail -c 6 {{.out}}/explicit.pdf | grep -q "%%EOF" && echo OK'
+        assertions:
+          - result.systemout ShouldContainSubstring "OK"
+      - type: exec
+        script: 'file -b --mime-type {{.out}}/explicit.pdf'
+        assertions:
+          - result.systemout ShouldContainSubstring "application/pdf"
+
+  - name: extension-based auto-detection produces a valid PDF
+    steps:
+      - type: exec
+        script: '{{.bin}} {{.fix}}/simple/headings.md {{.out}}/auto.pdf'
+        assertions:
+          - result.code ShouldEqual 0
+      - type: exec
+        script: 'head -c 5 {{.out}}/auto.pdf | grep -q "%PDF-" && tail -c 6 {{.out}}/auto.pdf | grep -q "%%EOF" && echo OK'
+        assertions:
+          - result.systemout ShouldContainSubstring "OK"
+
+  - name: PDF embeds title metadata extracted from first H1
+    steps:
+      - type: exec
+        script: 'grep -aE "/Title \(Heading Level One\)" {{.out}}/explicit.pdf | head -1'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "Heading Level One"
+
+  - name: page-break markdown produces a multi-page PDF
+    steps:
+      - type: exec
+        script: '{{.bin}} --format=pdf {{.fix}}/multi-page/pagebreak.md {{.out}}/multi.pdf'
+        assertions:
+          - result.code ShouldEqual 0
+      - type: exec
+        script: 'pages=$(grep -ac "/Type[ ]*/Page[^s]" {{.out}}/multi.pdf); echo "pages=$pages"; test "$pages" -ge 2'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "pages=3"
+
+  - name: page-size A4
+    steps:
+      - type: exec
+        script: '{{.bin}} --format=pdf --page-size=A4 {{.fix}}/simple/headings.md {{.out}}/a4.pdf && head -c 5 {{.out}}/a4.pdf | grep -q "%PDF-" && echo OK'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "OK"
+
+  - name: page-size Letter
+    steps:
+      - type: exec
+        script: '{{.bin}} --format=pdf --page-size=Letter {{.fix}}/simple/headings.md {{.out}}/letter.pdf && head -c 5 {{.out}}/letter.pdf | grep -q "%PDF-" && echo OK'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "OK"
+
+  - name: page-size Legal
+    steps:
+      - type: exec
+        script: '{{.bin}} --format=pdf --page-size=Legal {{.fix}}/simple/headings.md {{.out}}/legal.pdf && head -c 5 {{.out}}/legal.pdf | grep -q "%PDF-" && echo OK'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "OK"
+
+  - name: page-size A3
+    steps:
+      - type: exec
+        script: '{{.bin}} --format=pdf --page-size=A3 {{.fix}}/simple/headings.md {{.out}}/a3.pdf && head -c 5 {{.out}}/a3.pdf | grep -q "%PDF-" && echo OK'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "OK"
+
+  - name: page-size A5
+    steps:
+      - type: exec
+        script: '{{.bin}} --format=pdf --page-size=A5 {{.fix}}/simple/headings.md {{.out}}/a5.pdf && head -c 5 {{.out}}/a5.pdf | grep -q "%PDF-" && echo OK'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "OK"
+
+  - name: page-size Tabloid
+    steps:
+      - type: exec
+        script: '{{.bin}} --format=pdf --page-size=Tabloid {{.fix}}/simple/headings.md {{.out}}/tab.pdf && head -c 5 {{.out}}/tab.pdf | grep -q "%PDF-" && echo OK'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "OK"
+
+  - name: page-size lowercase a4 is accepted
+    steps:
+      - type: exec
+        script: '{{.bin}} --format=pdf --page-size=a4 {{.fix}}/simple/headings.md {{.out}}/a4lc.pdf && head -c 5 {{.out}}/a4lc.pdf | grep -q "%PDF-" && echo OK'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "OK"
+
+  - name: unknown page-size returns exit 1 with explanatory error
+    steps:
+      - type: exec
+        script: '{{.bin}} --format=pdf --page-size=Foo {{.fix}}/simple/headings.md {{.out}}/foo.pdf'
+        assertions:
+          - result.code ShouldEqual 1
+          - result.systemerr ShouldContainSubstring "unknown page size"
+
+  - name: margin in points (bare number)
+    steps:
+      - type: exec
+        script: '{{.bin}} --format=pdf --margin=90 {{.fix}}/simple/headings.md {{.out}}/m90.pdf && head -c 5 {{.out}}/m90.pdf | grep -q "%PDF-" && echo OK'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "OK"
+
+  - name: margin with pt suffix
+    steps:
+      - type: exec
+        script: '{{.bin}} --format=pdf --margin=90pt {{.fix}}/simple/headings.md {{.out}}/m90pt.pdf && head -c 5 {{.out}}/m90pt.pdf | grep -q "%PDF-" && echo OK'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "OK"
+
+  - name: margin in inches
+    steps:
+      - type: exec
+        script: '{{.bin}} --format=pdf --margin=1in {{.fix}}/simple/headings.md {{.out}}/min.pdf && head -c 5 {{.out}}/min.pdf | grep -q "%PDF-" && echo OK'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "OK"
+
+  - name: margin in centimeters
+    steps:
+      - type: exec
+        script: '{{.bin}} --format=pdf --margin=2.54cm {{.fix}}/simple/headings.md {{.out}}/mcm.pdf && head -c 5 {{.out}}/mcm.pdf | grep -q "%PDF-" && echo OK'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "OK"
+
+  - name: margin in millimeters
+    steps:
+      - type: exec
+        script: '{{.bin}} --format=pdf --margin=25.4mm {{.fix}}/simple/headings.md {{.out}}/mmm.pdf && head -c 5 {{.out}}/mmm.pdf | grep -q "%PDF-" && echo OK'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "OK"
+
+  - name: zero margin is accepted
+    steps:
+      - type: exec
+        script: '{{.bin}} --format=pdf --margin=0 {{.fix}}/simple/headings.md {{.out}}/m0.pdf && head -c 5 {{.out}}/m0.pdf | grep -q "%PDF-" && echo OK'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "OK"
+
+  - name: negative margin returns exit 1
+    steps:
+      - type: exec
+        script: '{{.bin}} --format=pdf --margin=-1in {{.fix}}/simple/headings.md {{.out}}/neg.pdf'
+        assertions:
+          - result.code ShouldEqual 1
+          - result.systemerr ShouldContainSubstring "must be non-negative"
+
+  - name: paragraph fixture renders to a valid PDF
+    steps:
+      - type: exec
+        script: '{{.bin}} --format=pdf {{.fix}}/simple/paragraph.md {{.out}}/paragraph.pdf && head -c 5 {{.out}}/paragraph.pdf | grep -q "%PDF-" && tail -c 6 {{.out}}/paragraph.pdf | grep -q "%%EOF" && echo OK'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "OK"
+
+  - name: lists fixture renders to a valid PDF
+    steps:
+      - type: exec
+        script: '{{.bin}} --format=pdf {{.fix}}/simple/lists.md {{.out}}/lists.pdf && head -c 5 {{.out}}/lists.pdf | grep -q "%PDF-" && tail -c 6 {{.out}}/lists.pdf | grep -q "%%EOF" && echo OK'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "OK"
+
+  - name: tables fixture renders to a valid PDF
+    steps:
+      - type: exec
+        script: '{{.bin}} --format=pdf {{.fix}}/tables/tables.md {{.out}}/tables.pdf && head -c 5 {{.out}}/tables.pdf | grep -q "%PDF-" && tail -c 6 {{.out}}/tables.pdf | grep -q "%%EOF" && echo OK'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "OK"
+
+  - name: smartypants typography renders to a valid PDF
+    steps:
+      - type: exec
+        script: '{{.bin}} --format=pdf {{.fix}}/typography/smarty.md {{.out}}/smarty.pdf && head -c 5 {{.out}}/smarty.pdf | grep -q "%PDF-" && tail -c 6 {{.out}}/smarty.pdf | grep -q "%%EOF" && echo OK'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "OK"
+
+  - name: fenced code blocks render to a valid PDF
+    steps:
+      - type: exec
+        script: '{{.bin}} --format=pdf {{.fix}}/code/fenced.md {{.out}}/fenced.pdf && head -c 5 {{.out}}/fenced.pdf | grep -q "%PDF-" && tail -c 6 {{.out}}/fenced.pdf | grep -q "%%EOF" && echo OK'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "OK"
+      - type: exec
+        script: 'grep -ao "/BaseFont /Courier" {{.out}}/fenced.pdf | head -1'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "/BaseFont /Courier"
+
+  - name: inline code renders to a valid PDF
+    steps:
+      - type: exec
+        script: '{{.bin}} --format=pdf {{.fix}}/code/inline.md {{.out}}/inline.pdf && head -c 5 {{.out}}/inline.pdf | grep -q "%PDF-" && tail -c 6 {{.out}}/inline.pdf | grep -q "%%EOF" && echo OK'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "OK"
+      - type: exec
+        script: 'grep -ao "/BaseFont /Courier" {{.out}}/inline.pdf | head -1'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "/BaseFont /Courier"
+
+  - name: markdown with embedded image renders to a valid PDF
+    steps:
+      - type: exec
+        script: '{{.bin}} --format=pdf {{.fix}}/images/img.md {{.out}}/img.pdf && head -c 5 {{.out}}/img.pdf | grep -q "%PDF-" && tail -c 6 {{.out}}/img.pdf | grep -q "%%EOF" && echo OK'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "OK"
+
+  - name: unsafe HTML markdown renders to a valid PDF
+    steps:
+      - type: exec
+        script: '{{.bin}} --format=pdf {{.fix}}/unsafe-html/script.md {{.out}}/unsafe.pdf && head -c 5 {{.out}}/unsafe.pdf | grep -q "%PDF-" && tail -c 6 {{.out}}/unsafe.pdf | grep -q "%%EOF" && echo OK'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "OK"

--- a/tst/integration/testsuite-validate.yml
+++ b/tst/integration/testsuite-validate.yml
@@ -1,0 +1,45 @@
+name: validate
+vars:
+  bin: ./mdtohtml
+  fix: tst/integration/fixtures
+testcases:
+  - name: well-formed markdown reports valid
+    steps:
+      - type: exec
+        script: '{{.bin}} validate {{.fix}}/simple/headings.md'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "is valid Markdown"
+          - result.systemerr ShouldBeEmpty
+
+  - name: tables are valid markdown
+    steps:
+      - type: exec
+        script: '{{.bin}} validate {{.fix}}/tables/tables.md'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "is valid Markdown"
+
+  - name: empty file is valid
+    steps:
+      - type: exec
+        script: '{{.bin}} validate {{.fix}}/invalid/empty.md'
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldContainSubstring "is valid Markdown"
+
+  - name: nonexistent file returns exit 1
+    steps:
+      - type: exec
+        script: '{{.bin}} validate {{.fix}}/does-not-exist.md'
+        assertions:
+          - result.code ShouldEqual 1
+          - result.systemerr ShouldContainSubstring "input file not found"
+
+  - name: directory passed to validate returns exit 1
+    steps:
+      - type: exec
+        script: '{{.bin}} validate {{.fix}}/simple'
+        assertions:
+          - result.code ShouldEqual 1
+          - result.systemerr ShouldContainSubstring "input path is a directory"


### PR DESCRIPTION
- new pkg/pdf wrapping folio v0.7.1 (Converter + Options + errors)
- --format / --page-size / --margin CLI flags
- PDF-only CSS override fixing folio font-family + rgba quirks
- tst/integration with 6 venom testsuites and 17 fixtures
- task integration target; results land in $PWD/results/

Closes #102