### PR TITLE
ci(linter): pin golangci-lint to v2.11.1

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -25,6 +25,8 @@ jobs:
         with:
           repo: golangci/golangci-lint
           cache: enable
+          tag: v2.11.1
+          binaries-location: golangci-lint-2.11.1-linux-amd64
 
       - name: Run linter
         shell: /usr/bin/bash {0}


### PR DESCRIPTION
- set explicit tag v2.11.1 on golangci-lint install action
- set binaries-location to golangci-lint-2.11.1-linux-amd64 for binary resolution

Closes #104